### PR TITLE
Added possibility to specify sway output or X screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,14 @@ Available commands:
   random  Choose a random image file from a given directory.
 ```
 
-Specify `-c`/`--comp` to pick an output compositor. `-c sway` will use `swaybg`
-to replace your Sway background, while the default `-c x11` will use `hsetroot`.
+Specify `-c`/`--comp` to pick an output compositor.\
+`-c sway` will use `swaybg`
+to replace your Sway background, while the default `-c x11` will use `hsetroot`.\
+Specify `-o`/`--output` to pick a sway output or X screen if using X11.\
+When using sway, use `-o "*"` to select all available outputs,\
+or specify multiple outputs separately (good if you want a different picture on each output when using `random`),\
+for example `-o DP-2 -o DP-3 -o HDMI-A-1`.\
+Specify `-k`/`--kill-swaybg` to kill existing swaybg processes.
 
 ## X11 Automation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,10 +105,14 @@ fn main() {
 
 fn work(args: Args) -> anyhow::Result<()> {
     match args.command {
-        Some(Cmd::Set(Set { output, image, comp, kill_swaybg, .. })) if image.is_file() => match comp {
+        Some(Cmd::Set(Set { mut output, image, comp, kill_swaybg, .. })) if image.is_file() => match comp {
                 Compositor::Sway => {
                     if kill_swaybg {
                         Command::new("pkill").arg("swaybg").output()?;
+                    }
+                    if output.is_empty() {
+                        output = Vec::new();
+                        output.push(String::from("*"));
                     }
                     let mut res: anyhow::Result<()> = Ok(());
                     for o in output {
@@ -117,6 +121,10 @@ fn work(args: Args) -> anyhow::Result<()> {
                     res
                 },
                 Compositor::X11 => {
+                    if output.is_empty() {
+                        output = Vec::new();
+                        output.push(std::option_env!("DISPLAY").unwrap_or(":0").to_string());
+                    }
                     let mut res: anyhow::Result<()> = Ok(());
                     for o in output {
                         res = hsetroot(o.as_str(), &image)
@@ -124,11 +132,15 @@ fn work(args: Args) -> anyhow::Result<()> {
                     res
                 },
         },
-        Some(Cmd::Random(Random { output, dir, comp, kill_swaybg, .. })) if dir.is_dir() => {
+        Some(Cmd::Random(Random { mut output, dir, comp, kill_swaybg, .. })) if dir.is_dir() => {
             match comp {
                 Compositor::Sway => {
                     if kill_swaybg {
                         Command::new("pkill").arg("swaybg").output()?;
+                    }
+                    if output.is_empty() {
+                        output = Vec::new();
+                        output.push(String::from("*"));
                     }
                     let mut res: anyhow::Result<()> = Ok(());
                     for o in output {
@@ -138,6 +150,10 @@ fn work(args: Args) -> anyhow::Result<()> {
                     res
                 },
                 Compositor::X11 => {
+                    if output.is_empty() {
+                        output = Vec::new();
+                        output.push(std::option_env!("DISPLAY").unwrap_or(":0").to_string());
+                    }
                     let mut res: anyhow::Result<()> = Ok(());
                     for o in output {
                         let p = rand_img(&dir)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,8 @@ struct Set {
     help: bool,
 
     /// Sway output to set background to or X screen number if using X11
-    #[options(help = "sway output name(s) or X screen number")]
-    outputs: Vec<String>,
+    #[options(help = "sway output name or X screen number")]
+    output: Vec<String>,
 
     /// The path to the image file.
     #[options(free)]
@@ -53,8 +53,8 @@ struct Random {
     help: bool,
 
     /// Sway output to set background to or X screen number if using X11
-    #[options(help = "sway output name(s) or X screen number")]
-    outputs: Vec<String>,
+    #[options(help = "sway output name or X screen number")]
+    output: Vec<String>,
 
     /// The path to choose an image file from.
     #[options(free)]
@@ -105,43 +105,43 @@ fn main() {
 
 fn work(args: Args) -> anyhow::Result<()> {
     match args.command {
-        Some(Cmd::Set(Set { outputs, image, comp, kill_swaybg, .. })) if image.is_file() => match comp {
+        Some(Cmd::Set(Set { output, image, comp, kill_swaybg, .. })) if image.is_file() => match comp {
                 Compositor::Sway => {
                     if kill_swaybg {
                         Command::new("pkill").arg("swaybg").output()?;
                     }
                     let mut res: anyhow::Result<()> = Ok(());
-                    for output in outputs {
-                        res = swaybg(output.as_str(), &image)
+                    for o in output {
+                        res = swaybg(o.as_str(), &image)
                     }
                     res
                 },
                 Compositor::X11 => {
                     let mut res: anyhow::Result<()> = Ok(());
-                    for output in outputs {
-                        res = hsetroot(output.as_str(), &image)
+                    for o in output {
+                        res = hsetroot(o.as_str(), &image)
                     }
                     res
                 },
         },
-        Some(Cmd::Random(Random { outputs, dir, comp, kill_swaybg, .. })) if dir.is_dir() => {
+        Some(Cmd::Random(Random { output, dir, comp, kill_swaybg, .. })) if dir.is_dir() => {
             match comp {
                 Compositor::Sway => {
                     if kill_swaybg {
                         Command::new("pkill").arg("swaybg").output()?;
                     }
                     let mut res: anyhow::Result<()> = Ok(());
-                    for output in outputs {
+                    for o in output {
                         let p = rand_img(&dir)?;
-                        res = swaybg(output.as_str(), &p)
+                        res = swaybg(o.as_str(), &p)
                     }
                     res
                 },
                 Compositor::X11 => {
                     let mut res: anyhow::Result<()> = Ok(());
-                    for output in outputs {
+                    for o in output {
                         let p = rand_img(&dir)?;
-                        res = hsetroot(output.as_str(), &p)
+                        res = hsetroot(o.as_str(), &p)
                     }
                     res
                 },


### PR DESCRIPTION
Hello, I added a possibility to specify a sway output or X screen using the `-o`/`--output` option, and `-k`/`--kill-swaybg` option so the user can specify whether or not they want to kill existing swaybg processes. I also updated the README file to reflect these changes.\
The motivation behind these additions was me moving from i3 to sway and not finding an alternative to the feh functionality I was using, specifically picking a picture from a directory randomly for each output. 
Now it can be done with this tool if you specify each output using the `-o` flags when using the `random` mode.